### PR TITLE
[BL-5651] Exclude .audio-sentences without a data-duration from the l…

### DIFF
--- a/src/pagePlayer/narration.ts
+++ b/src/pagePlayer/narration.ts
@@ -229,7 +229,7 @@ export default class Narration {
     }
 
     private static getAudioElements(): HTMLElement[] {
-        return [].concat.apply([], this.getRecordableDivs().map(x => this.findAll(".audio-sentence", x)));
+        return [].concat.apply([], this.getRecordableDivs().map(x => this.findAll(".audio-sentence[data-duration]", x)));
     }
 
     private static setCurrentSpan(current: Element, changeTo: HTMLElement): void {


### PR DESCRIPTION
…ist to be played so we don't highlight sentences without actual audio.

https://issues.bloomlibrary.org/youtrack/issue/BL-5651

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomplayer/6)
<!-- Reviewable:end -->
