### PR TITLE
[BL-5727] Undo previous fix and include all .audio-sentence spans in …

### DIFF
--- a/src/pagePlayer/narration.ts
+++ b/src/pagePlayer/narration.ts
@@ -229,7 +229,7 @@ export default class Narration {
     }
 
     private static getAudioElements(): HTMLElement[] {
-        return [].concat.apply([], this.getRecordableDivs().map(x => this.findAll(".audio-sentence[data-duration]", x)));
+        return [].concat.apply([], this.getRecordableDivs().map(x => this.findAll(".audio-sentence", x)));
     }
 
     private static setCurrentSpan(current: Element, changeTo: HTMLElement): void {


### PR DESCRIPTION
Undo previous fix and include all .audio-sentence spans in getAudioElements(). Some real live books have audio-sentences without a data-duration set.

https://silbloom.myjetbrains.com/youtrack/issue/BL-5727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomplayer/7)
<!-- Reviewable:end -->
